### PR TITLE
issue: could not set color tokens

### DIFF
--- a/packages/app/features/home/screen.tsx
+++ b/packages/app/features/home/screen.tsx
@@ -5,6 +5,8 @@ import {
   Paragraph,
   Separator,
   Sheet,
+  Stack,
+  styled,
   useToastController,
   XStack,
   YStack,
@@ -20,8 +22,8 @@ export function HomeScreen() {
 
   return (
     <YStack f={1} jc="center" ai="center" p="$4" space>
-      <YStack space="$4" maw={600}>
-        <H1 ta="center">Welcome to Tamagui.</H1>
+      <YStack space="$4" backgroundColor="$blue5" maw={600}>
+        <H1 color="$orange10" ta="center">Welcome to Tamagui.</H1>
         <Paragraph ta="center">
           Here's a basic starter to show navigating from one screen to another. This screen uses the
           same code on Next.js and React Native.

--- a/packages/app/provider/index.tsx
+++ b/packages/app/provider/index.tsx
@@ -10,7 +10,7 @@ export function Provider({ children, ...rest }: Omit<TamaguiProviderProps, 'conf
     <TamaguiProvider
       config={config}
       disableInjectCSS
-      defaultTheme={scheme === 'dark' ? 'dark' : 'light'}
+      defaultTheme={scheme === 'dark' ? 'dark_green' : 'light_green'}
       {...rest}
     >
       <ToastProvider


### PR DESCRIPTION
# Issue Reproduction

## Setting theme is `light` or `dark`

<img width="466" alt="Screenshot 2023-09-29 at 20 35 37" src="https://github.com/zcmgyu/tamagui-demo/assets/13638569/f8d7c4a6-1689-4ca4-8343-64d97250b499">

All color tokens passed to Component has displayed as expected

## After switch theme to `light_green` or `green_dark`, everything’s gone

<img width="466" alt="Screenshot 2023-09-29 at 20 35 13" src="https://github.com/zcmgyu/tamagui-demo/assets/13638569/4bd75529-cf06-4e4c-ba31-87c96c697164">

